### PR TITLE
add get_contracts function and overview for cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 *.egg-info/*
 __pycache__
+assets/
+bin/
+contracts/
+invoices/
+lib*
+pyvenv.cfg
+settings.yaml
+share/

--- a/rechnung/cli.py
+++ b/rechnung/cli.py
@@ -48,10 +48,11 @@ def print_contracts():
     """
     Print an overview of all contracs
     """
-    for cid, contract in get_contracts(cwd).items():
-        if not "slug" in contract:
-            contract["slug"] = contract["email"]
-        print("{cid}: {slug} {opening} {monthly}€".format(**contract))
+    settings = get_settings_from_cwd(cwd)
+    for cid, data in get_contracts(settings).items():
+        slug = data.get("email", "unknown")
+        total_monthly = sum(map(lambda i: i["price"], data["items"]))
+        print(f"{cid}: {slug} {data['start']} {total_monthly}€")
 
 
 @cli1.command()
@@ -59,11 +60,14 @@ def print_stats():
     """
     Print stats about the contracts
     """
-    contracts = get_contracts(cwd).values()
+    settings = get_settings_from_cwd(cwd)
+    contracts = get_contracts(settings).values()
     print(f"{len(contracts)} contracts in total")
 
-    total_monthly = sum(map(lambda c: int(c["monthly"]), contracts))
-    print(f"{total_monthly}€ per month")
+    total_monthly = sum(
+        map(lambda x: x[0]["price"], list(map(lambda i: i["items"], contracts)))
+    )
+    print(f"{total_monthly:.2f}€ per month")
 
 
 @cli1.command()

--- a/rechnung/cli.py
+++ b/rechnung/cli.py
@@ -67,14 +67,6 @@ def print_stats():
 
 
 @cli1.command()
-def contracts():
-    """
-    Mass create contracts.
-    """
-    print("Not yet implemented")
-
-
-@cli1.command()
 def render():
     """
     Render all unrendered invoices.
@@ -86,13 +78,13 @@ def render():
 
 
 @cli1.command()
-@click.argument("year")
-@click.argument("month")
+@click.argument("year", type=int)
+@click.argument("month", type=int)
 def send(year, month):
     """
     Send invoices by email.
     """
-    print("Sending invoices *.{}".format(year_suffix))
+    print(f"Sending invoices for {year}.{month:02}")
     settings = get_settings_from_cwd(cwd)
     send_invoices(settings, year, month)
 
@@ -103,7 +95,7 @@ def send_contract_mail(cid):
     """
     Send contract by email.
     """
-    print("Sending contract {}".format(cid))
+    print(f"Sending contract {cid}")
     settings = get_settings_from_cwd(cwd)
     send_contract(settings, cid)
 

--- a/rechnung/cli.py
+++ b/rechnung/cli.py
@@ -32,8 +32,8 @@ def init():
 
 
 @cli1.command()
-@click.argument("year")
-@click.argument("month")
+@click.argument("year", type=int)
+@click.argument("month", type=int)
 def create(year, month):
     """
     Mass create invoices.
@@ -90,7 +90,7 @@ def send(year, month):
 
 
 @cli1.command()
-@click.argument("cid")
+@click.argument("cid", type=int)
 def send_contract_mail(cid):
     """
     Send contract by email.

--- a/rechnung/cli.py
+++ b/rechnung/cli.py
@@ -69,7 +69,7 @@ def print_stats():
 @cli1.command()
 def render():
     """
-    Render all unrendered invoices.
+    Render all unrendered invoices and contracs
     """
     print("Rendering invoices and contracts...")
     settings = get_settings_from_cwd(cwd)

--- a/rechnung/contract.py
+++ b/rechnung/contract.py
@@ -17,7 +17,7 @@ from .helpers import (
 
 def get_contracts(settings):
     contracts = {}
-    for filename in os.listdir(settings.contracts_dir):
+    for filename in settings.contracts_dir.glob("*.yaml"):
 
         if not filename.endswith(".yaml"):
             continue
@@ -29,8 +29,7 @@ def get_contracts(settings):
     return contracts
 
 
-def generate_contract(customer, positions):
-
+def create_contract(customer, positions):
     contract_data = customer
     contract_data["product"] = positions[0]
     contract_data["product"]["price"] = round(positions[0]["price"] * 1.19, 2)
@@ -88,7 +87,7 @@ def save_contract_yaml(contracts_dir, contract_data):
 def create_yaml_contracts(contracts_dir, customers, positions):
     for cid in customers.keys():
         print("Creating contract yaml for {}".format(cid))
-        contract_data = generate_contract(customers[cid], positions[cid])
+        contract_data = create_contract(customers[cid], positions[cid])
         save_contract_yaml(contracts_dir, contract_data)
 
 
@@ -127,7 +126,7 @@ def send_contract(settings, cid):
 
         if settings.policy_attachment_asset_file:
             policy_pdf_file = settings.policy_attachment_asset_file
-            policy_pdf_path = Path(settings.assets_dir / policy_pdf_file)
+            policy_pdf_path = settings.assets_dir / policy_pdf_file
             if policy_pdf_path.is_file():
                 policy_pdf = get_pdf(policy_pdf_path)
                 pdf_documents.append(policy_pdf)

--- a/rechnung/contract.py
+++ b/rechnung/contract.py
@@ -92,7 +92,8 @@ def create_yaml_contracts(contracts_dir, customers, positions):
         save_contract_yaml(contracts_dir, contract_data)
 
 
-def send_contract_mail(settings, mail_template, cid):
+def send_contract(settings, cid):
+    mail_template = get_template(settings.contract_mail_template_file)
     contract_pdf_path = Path(settings.contracts_dir) / f"{cid}.pdf"
     contract_yaml_filename = Path(settings.contracts_dir) / f"{cid}.yaml"
 
@@ -149,8 +150,3 @@ def send_contract_mail(settings, mail_template, cid):
 def create_contracts(settings):
     positions = get_positions(settings.positions_dir)
     create_yaml_contracts(settings.contracts_dir)
-
-
-def send_contract(settings, cid):
-    mail_template = get_template(settings.contract_mail_template_file)
-    send_contract_mail(settings, mail_template, cid)

--- a/rechnung/invoice.py
+++ b/rechnung/invoice.py
@@ -54,7 +54,7 @@ def generate_invoice(settings, contract, year, month):
     invoice_data["date"] = datetime.datetime.now().strftime(
         settings.delivery_date_format
     )
-    invoice_data["id"] = f"{contract['cid']}.{year}.{mont:02}"
+    invoice_data["id"] = f"{contract['cid']}.{year}.{month:02}"
     invoice_data["period"] = "{}-{}".format(year, month)
     invoice_data["total_gross"] = gross
     invoice_data["total_net"] = net
@@ -178,8 +178,6 @@ def send_invoices(settings, year, month):
                 )
 
                 print(f"Sending invoice {invoice_data['id']}")
-
-                print(invoice_email)
 
                 send_email(
                     invoice_email,

--- a/rechnung/invoice.py
+++ b/rechnung/invoice.py
@@ -2,9 +2,11 @@ import datetime
 import locale
 import os
 import os.path
+from pathlib import Path
 import yaml
 
 from .settings import get_settings_from_cwd
+from .contract import get_contracts
 from .helpers import (
     generate_pdf,
     get_pdf,
@@ -14,22 +16,22 @@ from .helpers import (
 )
 
 
-def fill_invoice_positions(positions, n_months, settings):
+def fill_invoice_items(settings, items):
     invoice_total_net = float()
     invoice_total_vat = float()
     invoice_total_gross = float()
 
-    invoice_positions = []
+    invoice_items = []
 
-    for n_e, position in enumerate(positions):
-        final_quantity = n_months * position["quantity"]
-        subtotal = round(final_quantity * position["price"], 2)
+    for n_e, item in enumerate(items):
+        final_quantity = item.get("quantity", 1)
+        subtotal = round(final_quantity * item["price"], 2)
 
-        invoice_positions.append(
+        invoice_items.append(
             {
-                "position": n_e + 1,
-                "description": position["description"],
-                "price": position["price"],
+                "item": n_e + 1,
+                "description": item["description"],
+                "price": item["price"],
                 "quantity": final_quantity,
                 "subtotal": subtotal,
             }
@@ -40,69 +42,54 @@ def fill_invoice_positions(positions, n_months, settings):
     invoice_total_net = round(invoice_total_gross / (1.0 + settings.vat / 100.0), 2)
     invoice_total_vat = round(invoice_total_gross - invoice_total_net, 2)
 
-    return (
-        invoice_positions,
-        invoice_total_net,
-        invoice_total_vat,
-        invoice_total_gross,
-    )
+    return (invoice_items, invoice_total_net, invoice_total_vat, invoice_total_gross)
 
 
-def generate_invoice(
-    customer, positions, start_date, end_date, n_months, year, suffix, settings
-):
-
-    invoice_positions, net, vat, gross = fill_invoice_positions(
-        positions, n_months, settings
-    )
+def generate_invoice(settings, contract, year, month):
+    invoice_items, net, vat, gross = fill_invoice_items(settings, contract["items"])
 
     invoice_data = {}
-    invoice_data["address"] = customer["address"]
-    invoice_data["cid"] = customer["cid"]
-    invoice_data["date"] = datetime.datetime.now().strftime("%d. %B %Y")
-    invoice_data["id"] = "{}.{}.{}".format(customer["cid"], year, suffix)
-    invoice_data["period"] = "{} - {}".format(start_date, end_date)
+    invoice_data["address"] = contract.get("address", ["", "", ""])
+    invoice_data["cid"] = contract["cid"]
+    invoice_data["date"] = datetime.datetime.now().strftime(
+        settings.delivery_date_format
+    )
+    invoice_data["id"] = "{}.{}.{}".format(contract["cid"], year, month)
+    invoice_data["period"] = "{}-{}".format(year, month)
     invoice_data["total_gross"] = gross
     invoice_data["total_net"] = net
     invoice_data["total_vat"] = vat
     invoice_data["vat"] = settings.vat
-
-    if "email" not in customer.keys():
-        invoice_data["email"] = None
-    else:
-        invoice_data["email"] = customer["email"]
-
-    return (invoice_data, invoice_positions)
+    invoice_data["email"] = contract["email"]
+    invoice_data["items"] = invoice_items
+    return invoice_data
 
 
 def iterate_invoices(invoices_dir):
     """
-    Generator which iterates over all customer directories and
-    included invoice yamls, yields customer_invoice_dir and filename.
+    Generator which iterates over all contract directories and
+    included invoice yamls, yields contract_invoice_dir and filename.
     """
     for d in os.listdir(invoices_dir):
-        customer_invoice_dir = os.path.join(invoices_dir, d)
-        if os.path.isdir(customer_invoice_dir):
-            for filename in os.listdir(customer_invoice_dir):
+        contract_invoice_dir = os.path.join(invoices_dir, d)
+        if os.path.isdir(contract_invoice_dir):
+            for filename in os.listdir(contract_invoice_dir):
 
                 if not filename.endswith(".yaml"):
                     continue
 
-                yield customer_invoice_dir, filename
+                yield contract_invoice_dir, filename
 
+def render_invoices(settings):
+    template = get_template(settings.invoice_template_file)
+    logo_path = Path(settings.assets_dir / "logo.svg")
 
-def render_pdf_invoices(directory, template, settings):
-
-    logo_path = os.path.join(settings.assets_dir, "logo.svg")
-
-    for customer_invoice_dir, filename in iterate_invoices(settings.invoices_dir):
+    for contract_invoice_dir, filename in iterate_invoices(settings.invoices_dir):
         if not os.path.isfile(
-            "{}.pdf".format(os.path.join(customer_invoice_dir, filename[:-5]))
+            "{}.pdf".format(os.path.join(contract_invoice_dir, filename[:-5]))
         ):
-            with open(os.path.join(customer_invoice_dir, filename)) as yaml_file:
-                invoice_data, invoice_positions = yaml.load(
-                    yaml_file.read(), Loader=yaml.FullLoader
-                )
+            with open(os.path.join(contract_invoice_dir, filename)) as yaml_file:
+                invoice_data = yaml.safe_load(yaml_file.read())
             invoice_data["logo_path"] = logo_path
             invoice_data["company"] = settings.company
 
@@ -113,172 +100,49 @@ def render_pdf_invoices(directory, template, settings):
                 invoice_data[element] = locale.format_string(
                     "%.2f", invoice_data[element]
                 )
-            for position in invoice_positions:
+            for item in invoice_data["items"]:
                 for key in ["price", "subtotal"]:
-                    position[key] = locale.format_string("%.2f", position[key])
+                    item[key] = locale.format_string("%.2f", item[key])
 
             invoice_html = template.render(
-                positions=invoice_positions, invoice=invoice_data
+                invoice=invoice_data
             )
 
             invoice_pdf_filename = os.path.join(
-                customer_invoice_dir, "{}.pdf".format(invoice_data["id"])
+                contract_invoice_dir, "{}.pdf".format(invoice_data["id"])
             )
             generate_pdf(
                 invoice_html, settings.invoice_css_asset_file, invoice_pdf_filename
             )
 
 
-def save_invoice_yaml(invoices_dir, invoice_data, invoice_positions):
-    invoice_customer_dir = os.path.join(invoices_dir, invoice_data["cid"])
-    if not os.path.isdir(invoice_customer_dir):
-        os.mkdir(invoice_customer_dir)
+def save_invoice_yaml(settings, invoice_data):
+    invoice_contract_dir = Path(settings.invoices_dir / invoice_data["cid"])
 
-    outfilename = os.path.join(
-        invoice_customer_dir, "{}.yaml".format(invoice_data["id"])
-    )
+    if not os.path.isdir(invoice_contract_dir):
+        os.mkdir(invoice_contract_dir)
+
+    outfilename = invoice_contract_dir / f"{invoice_data['id']}.yaml"
     try:
         with open(outfilename, "x") as outfile:
-            outfile.write(
-                yaml.dump([invoice_data, invoice_positions], default_flow_style=False)
-            )
+            outfile.write(yaml.dump(invoice_data, default_flow_style=False))
     except FileExistsError:
         print("Invoice {} already exists.".format(outfilename))
 
 
-def create_yaml_invoices(
-    invoices_dir,
-    customers,
-    positions,
-    start_date,
-    end_date,
-    n_months,
-    year,
-    suffix,
-    settings,
-):
+def create_invoices(settings, year, month):
+    contracts = get_contracts(settings)
+    create_yaml_invoices(settings, contracts, year, month)
 
-    for cid in customers.keys():
+
+def create_yaml_invoices(settings, contracts, year, month):
+    for cid, contract in contracts.items():
         print("Creating invoice yaml for {}".format(cid))
-        invoice_data, invoice_positions = generate_invoice(
-            customers[cid],
-            positions[cid],
-            start_date,
-            end_date,
-            n_months,
-            year,
-            suffix,
-            settings,
-        )
-        save_invoice_yaml(invoices_dir, invoice_data, invoice_positions)
+        invoice_data = generate_invoice(settings, contract, year, month)
+        save_invoice_yaml(settings, invoice_data)
 
 
-def get_customers(customers_dir):
-    customers = {}
-    for filename in os.listdir(customers_dir):
 
-        if not filename.endswith(".yaml"):
-            continue
-
-        origin_file = os.path.join(customers_dir, filename)
-        with open(origin_file, "r") as infile:
-            customer = yaml.load(infile, Loader=yaml.FullLoader)
-
-        customers[customer["cid"]] = customer
-    return customers
-
-
-def get_positions(positions_dir):
-    positions = {}
-    for filename in os.listdir(positions_dir):
-
-        if not filename.endswith(".yaml"):
-            continue
-
-        origin_file = os.path.join(positions_dir, filename)
-        cid = filename.split(".")[0]
-        with open(origin_file, "r") as infile:
-            position = yaml.load(infile, Loader=yaml.FullLoader)
-        positions[cid] = position
-    return positions
-
-
-def send_invoice_mails(settings, mail_template, year_suffix):
-
-    for d in os.listdir(settings.invoices_dir):
-        customer_invoice_dir = os.path.join(settings.invoices_dir, d)
-        if os.path.isdir(customer_invoice_dir):
-            for filename in os.listdir(customer_invoice_dir):
-
-                if not filename.endswith(".yaml"):
-                    continue
-
-                file_suffix = ".".join(filename.split(".")[-3:-1])
-
-                if file_suffix != year_suffix:
-                    continue
-
-                with open(os.path.join(customer_invoice_dir, filename)) as yaml_file:
-                    invoice_data, invoice_positions = yaml.load(
-                        yaml_file, Loader=yaml.FullLoader
-                    )
-
-                if invoice_data["email"] is None:
-                    continue
-
-                invoice_pdf_path = os.path.join(
-                    customer_invoice_dir, "{}.pdf".format(filename[:-5])
-                )
-                invoice_pdf_filename = "Westnetz_Rechnung_{}.pdf".format(filename[:-5])
-                invoice_mail_text = mail_template.render(invoice=invoice_data)
-                invoice_pdf = get_pdf(invoice_pdf_path)
-
-                invoice_receiver = invoice_data["email"]
-
-                invoice_email = generate_email_with_pdf_attachment(
-                    invoice_receiver,
-                    settings.sender,
-                    settings.invoice_mail_subject,
-                    invoice_mail_text,
-                    invoice_pdf,
-                    invoice_pdf_filename,
-                )
-
-                print("Sending invoice {}".format(invoice_data["id"]))
-
-                send_email(
-                    invoice_email,
-                    settings.server,
-                    settings.username,
-                    settings.password,
-                    settings.insecure,
-                )
-
-
-def create_invoices(directory, start_date, end_date, n_months, year, suffix):
-    settings = get_settings_from_cwd(directory)
-    customers = get_customers(settings.customers_dir)
-    positions = get_positions(settings.positions_dir)
-    create_yaml_invoices(
-        settings.invoices_dir,
-        customers,
-        positions,
-        start_date,
-        end_date,
-        n_months,
-        year,
-        suffix,
-        settings,
-    )
-
-
-def render_invoices(directory):
-    settings = get_settings_from_cwd(directory)
-    template = get_template(settings.invoice_template_file)
-    render_pdf_invoices(directory, template, settings)
-
-
-def send_invoices(directory, year_suffix):
-    settings = get_settings_from_cwd(directory)
+def send_invoices(settings, year, month):
     mail_template = get_template(settings.invoice_mail_template_file)
-    send_invoice_mails(settings, mail_template, year_suffix)
+    send_invoice_mails(settings, mail_template, year, month)

--- a/rechnung/invoice.py
+++ b/rechnung/invoice.py
@@ -55,7 +55,7 @@ def generate_invoice(settings, contract, year, month):
         settings.delivery_date_format
     )
     invoice_data["id"] = f"{contract['cid']}.{year}.{month:02}"
-    invoice_data["period"] = "{}-{}".format(year, month)
+    invoice_data["period"] = f"{year}.{month}"
     invoice_data["total_gross"] = gross
     invoice_data["total_net"] = net
     invoice_data["total_vat"] = vat
@@ -93,7 +93,7 @@ def render_invoices(settings):
             invoice_data["logo_path"] = logo_path
             invoice_data["company"] = settings.company
 
-            print("Rendering invoice pdf for {}".format(invoice_data["id"]))
+            print(f"Rendering invoice pdf for {invoice_data['id']}")
 
             # Format data for printing
             for element in ["total_net", "total_gross", "total_vat"]:
@@ -117,25 +117,25 @@ def render_invoices(settings):
 def save_invoice_yaml(settings, invoice_data):
     invoice_contract_dir = settings.invoices_dir / invoice_data["cid"]
 
-    if not invoice_contract_dir.iterdir():
-        os.mkdir(invoice_contract_dir)
+    if not invoice_contract_dir.is_dir():
+        invoice_contract_dir.mkdir()
 
     outfilename = invoice_contract_dir / f"{invoice_data['id']}.yaml"
     try:
         with open(outfilename, "x") as outfile:
             outfile.write(yaml.dump(invoice_data, default_flow_style=False))
     except FileExistsError:
-        print("Invoice {} already exists.".format(outfilename))
+        print(f"Invoice {outfilename} already exists.")
 
 
 def create_invoices(settings, year, month):
-    contracts = get_contracts(settings)
+    contracts = get_contracts(settings, year, month)
     create_yaml_invoices(settings, contracts, year, month)
 
 
 def create_yaml_invoices(settings, contracts, year, month):
     for cid, contract in contracts.items():
-        print("Creating invoice yaml for {}".format(cid))
+        print(f"Creating invoice yaml {cid}.{year}.{month}")
         invoice_data = generate_invoice(settings, contract, year, month)
         save_invoice_yaml(settings, invoice_data)
 

--- a/rechnung/orig/sample.contract.yaml
+++ b/rechnung/orig/sample.contract.yaml
@@ -3,10 +3,14 @@ address:
 - "Rosa-Luxemburg-Allee 161"
 - 04161 Leipzig
 cid: '1000'
-dob: '1954-03-21'
+dob: 1954-03-21
+start: 2019-06-01
 email: martha.muster@email.tld
 name: Martha Muster
 notify: false
 phone: '+491234567890'
 slug: martha_muster
-vid: 1000
+items:
+  - description: A great product
+    price: 13.37
+    quantity: 1

--- a/rechnung/orig/sample.positions.yaml
+++ b/rechnung/orig/sample.positions.yaml
@@ -1,3 +1,0 @@
-- description: A great product
-  price: 13.37
-  quantity: 1

--- a/rechnung/settings.py
+++ b/rechnung/settings.py
@@ -20,30 +20,29 @@ od = pd / ORIG_DIR
 # in the settings.yaml
 required_settings = [
     "company",
-    "vat",
-    "locale",
-    "delivery_date_format",
-    "invoice_mail_subject",
     "contract_mail_subject",
+    "insecure",
+    "invoice_mail_subject",
+    "locale",
+    "password",
     "sender",
     "server",
     "username",
-    "password",
-    "insecure",
-    "policy_attachment_asset_file",
+    "vat",
 ]
 optional_settings = {
-    "contracts_dir": "contracts",
-    "customers_dir": "customers",
-    "positions_dir": "positions",
-    "invoices_dir": "invoices",
     "assets_dir": "assets",
-    "contract_mail_template_file": "contract_mail_template.j2",
     "contract_css_asset_file": "contract.css",
+    "contract_mail_template_file": "contract_mail_template.j2",
     "contract_template_file": "contract_template.j2.html",
-    "invoice_mail_template_file": "invoice_mail_template.j2",
+    "contracts_dir": "contracts",
+    "delivery_date_format": "%d. %B %Y",
     "invoice_css_asset_file": "invoice.css",
+    "invoice_mail_template_file": "invoice_mail_template.j2",
     "invoice_template_file": "invoice_template.j2.html",
+    "invoices_dir": "invoices",
+    "policy_attachment_asset_file": "policy.md",
+    "positions_dir": "positions",
 }
 possible_settings = set(required_settings + list(optional_settings.keys()))
 
@@ -60,14 +59,14 @@ class RequiredSettingMissingError(Exception):
 
 def create_required_settings_file(cwd, settings_file=SETTINGS_FILE):
     """
-    Creates a settings file with all required settings listed, to 
+    Creates a settings file with all required settings listed, to
     be filled by the user accordingly.
     """
     settings_path = Path(cwd) / settings_file
     if settings_path.exists():
         raise FileExistsError("Settings file already exists.")
     with open(settings_path, "w") as s_file:
-        yaml.dump(dict.fromkeys(required_settings), s_file)
+        yaml.dump(dict.fromkeys(possible_settings), s_file)
     return settings_path
 
 

--- a/rechnung/settings.py
+++ b/rechnung/settings.py
@@ -42,8 +42,7 @@ optional_settings = {
     "invoice_template_file": "invoice_template.j2.html",
     "invoices_dir": "invoices",
     "logo_file": "logo.svg",
-    "policy_attachment_asset_file": None,
-    "positions_dir": "positions",
+    "policy_attachment_asset_file": "policy.pdf",
 }
 possible_settings = set(required_settings + list(optional_settings.keys()))
 
@@ -121,6 +120,7 @@ def get_settings_from_file(
 
         # prepend base_path to all _dir and _file settings
         for s_key, s_value in settings_data.items():
+            # print(s_key, s_value)
             if s_key.endswith(("_file", "_dir")):
                 if s_key.endswith(("_asset_file", "_template_file")):
                     s_value = base_path / settings_data["assets_dir"] / s_value

--- a/rechnung/settings.py
+++ b/rechnung/settings.py
@@ -41,6 +41,7 @@ optional_settings = {
     "invoice_mail_template_file": "invoice_mail_template.j2",
     "invoice_template_file": "invoice_template.j2.html",
     "invoices_dir": "invoices",
+    "logo_file": "logo.svg",
     "policy_attachment_asset_file": None,
     "positions_dir": "positions",
 }
@@ -66,7 +67,7 @@ def create_required_settings_file(cwd, settings_file=SETTINGS_FILE):
     if settings_path.exists():
         raise FileExistsError("Settings file already exists.")
     with open(settings_path, "w") as s_file:
-        yaml.dump(dict.fromkeys(possible_settings), s_file)
+        yaml.dump(dict.fromkeys(required_settings), s_file)
     return settings_path
 
 

--- a/rechnung/settings.py
+++ b/rechnung/settings.py
@@ -41,7 +41,7 @@ optional_settings = {
     "invoice_mail_template_file": "invoice_mail_template.j2",
     "invoice_template_file": "invoice_template.j2.html",
     "invoices_dir": "invoices",
-    "policy_attachment_asset_file": "policy.md",
+    "policy_attachment_asset_file": None,
     "positions_dir": "positions",
 }
 possible_settings = set(required_settings + list(optional_settings.keys()))


### PR DESCRIPTION
now there are only contracts that contain user information and also
billed items. The contract should contain all required information for
generating invoices.

The suffix feature was removed for now in favor for for a year/month
structure to keep things simple. It's easy to extend the cli to create
invoices in batch over multiple month, using suffixes makes thing far
more complicated.

Instead of loading the settings multiple times it is now loaded in the
cli and passed down to other function.

sample.contract.yml contains a fully featured contract, however the
contract template is still incomplete and don't handle all given
information.

"positions" were whereever replaces by "items", separation of
invoice_data and invoice_positons also merged.

add the cli command print-contracts and print-stats to get an overview

Signed-off-by: Paul Spooren <mail@aparcar.org>