### PR TITLE
updated requirements to be compatible with Python3.8

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,39 +7,37 @@
 appdirs==1.4.3            # via black
 arrow==0.13.1
 atomicwrites==1.3.0       # via pytest
-attrs==19.2.0             # via black, pytest
+attrs==19.3.0             # via black, pytest
 black==19.3b0
 cairocffi==1.1.0
 cairosvg==2.4.2
-cffi==1.12.3
+cffi==1.13.2
 click==7.0
 coverage==4.5.4           # via pytest-cov
 cssselect2==0.2.2
 defusedxml==0.6.0
 html5lib==1.0.1
-importlib-metadata==0.23  # via pluggy, pytest
 jinja2==2.10.3
 markupsafe==1.1.1
-more-itertools==7.2.0     # via pytest, zipp
+more-itertools==7.2.0     # via pytest
 packaging==19.2           # via pytest
-pillow==6.2.0
+pillow==6.2.1
 pip-tools==3.6.0
 pluggy==0.13.0            # via pytest
 py==1.8.0                 # via pytest
 pycparser==2.19
-pyparsing==2.4.2          # via packaging
+pyparsing==2.4.4          # via packaging
 pyphen==0.9.5
 pytest-cov==2.8.1
 pytest==5.2.1
-python-dateutil==2.8.0
+python-dateutil==2.8.1
 pyyaml==5.1
-six==1.12.0
+six==1.13.0
 tinycss2==1.0.2
 toml==0.10.0              # via black
 wcwidth==0.1.7            # via pytest
 weasyprint==47
 webencodings==0.5.1
-zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.4.0        # via cairocffi, tinycss2, weasyprint
+# setuptools==41.6.0        # via cairocffi, tinycss2, weasyprint

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,22 +7,22 @@
 arrow==0.13.1
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-cffi==1.12.3              # via cairocffi, weasyprint
+cffi==1.13.2              # via cairocffi, weasyprint
 click==7.0
 cssselect2==0.2.2         # via cairosvg, weasyprint
 defusedxml==0.6.0         # via cairosvg
 html5lib==1.0.1           # via weasyprint
 jinja2==2.10.3
 markupsafe==1.1.1         # via jinja2
-pillow==6.2.0             # via cairosvg
+pillow==6.2.1             # via cairosvg
 pycparser==2.19           # via cffi
 pyphen==0.9.5             # via weasyprint
-python-dateutil==2.8.0    # via arrow
+python-dateutil==2.8.1    # via arrow
 pyyaml==5.1
-six==1.12.0               # via html5lib, python-dateutil
+six==1.13.0               # via html5lib, python-dateutil
 tinycss2==1.0.2           # via cairosvg, cssselect2, weasyprint
 weasyprint==47
 webencodings==0.5.1       # via html5lib, tinycss2
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.4.0        # via cairocffi, tinycss2, weasyprint
+# setuptools==41.6.0        # via cairocffi, tinycss2, weasyprint


### PR DESCRIPTION
Unfortunately pyparsing and html5lib are still using
the deprecated ABCs from collections import which
was to be disabled in Python 3.8 already, but is now
scheduled to be dropped in Python3.9. I hope we will
see a new release of html5lib until then.